### PR TITLE
Add github actions

### DIFF
--- a/.github/workflows/build-BinaryBH-example.yml
+++ b/.github/workflows/build-BinaryBH-example.yml
@@ -1,0 +1,51 @@
+name: Run GRChombo Tests (GCC)
+
+on: [push]
+
+jobs:
+  build-BinaryBH-example:
+    runs-on: ubuntu-20.04
+    env:
+      CHOMBO_HOME: ${{ github.workspace }}/Chombo/lib
+      TWOPUNCTURES_SOURCE: ${{ github.workspace }}/TwoPunctures/Source
+      OMP_NUM_THREADS: 1
+
+    steps:
+    - name: Checkout Chombo
+      uses: actions/checkout@v2
+      with:
+        repository: GRChombo/Chombo
+        path: Chombo
+
+    - name: Checkout GRChombo
+      uses: actions/checkout@v2
+      with:
+        repository: GRChombo/GRChombo
+        path: GRChombo
+
+    - name: Checkout TwoPunctures
+      uses: actions/checkout@v2
+      with:
+        path: TwoPunctures
+
+    - name: Install Chombo dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get -y --no-install-recommends install csh gfortran-10 g++-10 cpp-10 libhdf5-dev libhdf5-openmpi-dev openmpi-bin libblas-dev liblapack-dev libgetopt-complete-perl
+
+    - name: Set Compilers
+      run: |
+        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 100
+        sudo update-alternatives --install /usr/bin/gfortran gfortran /usr/bin/gfortran-10 100
+        sudo update-alternatives --install /usr/bin/cpp cpp /usr/bin/cpp-10 100
+
+    - name: Build Chombo
+      run: |
+        cp $GITHUB_WORKSPACE/GRChombo/InstallNotes/MakeDefsLocalExamples/ubuntu-18.04.Make.defs.local $CHOMBO_HOME/mk/Make.defs.local
+        make -j 4 AMRTimeDependent AMRTools BaseTools BoxTools
+      working-directory: ${{ env.CHOMBO_HOME }}
+
+    - name: Build BinaryBH example with TwoPunctures
+      run: |
+        make all -j 4
+      working-directory: ${{ github.workspace }}/GRChombo/Examples/BinaryBH

--- a/.github/workflows/build-BinaryBH-example.yml
+++ b/.github/workflows/build-BinaryBH-example.yml
@@ -1,6 +1,9 @@
-name: Run GRChombo Tests (GCC)
+name: Build BinaryBH example with TwoPunctures
 
-on: [push]
+on:
+  schedule:
+    # Run once per month
+    - cron:  '0 0 1 * *'
 
 jobs:
   build-BinaryBH-example:

--- a/.github/workflows/test-clang-format.yml
+++ b/.github/workflows/test-clang-format.yml
@@ -1,0 +1,15 @@
+name: Check Clang Format
+
+on: [push]
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: DoozyX/clang-format-lint-action@v0.11
+      with:
+        source: '.'
+        extensions: 'hpp,cpp'
+        clangFormatVersion: 10

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # TwoPunctures (GRChombo)
 
+![Build BinaryBH example with TwoPunctures](https://github.com/GRChombo/TwoPunctures/workflows/Build%20BinaryBH%20example%20with%20TwoPunctures/badge.svg)
+![Check Clang Format](https://github.com/GRChombo/TwoPunctures/workflows/Check%20Clang%20Format/badge.svg)
+
 This repository originates from the
 [standalone TwoPunctures](https://bitbucket.org/relastro/twopunctures-standalone)
 code which in turn comes from the original Einstein Toolkit thorn


### PR DESCRIPTION
This adds an action to build the GRChombo BinaryBH example with TwoPunctures once a month and also check the clang-formatting of the code. This fixes #1.