### PR TITLE
Replace C `free()`s with C++ `delete[]`s for deallocating dynamic memory

### DIFF
--- a/.github/workflows/build-BinaryBH-example.yml
+++ b/.github/workflows/build-BinaryBH-example.yml
@@ -45,7 +45,7 @@ jobs:
 
     - name: Build Chombo
       run: |
-        cp $GITHUB_WORKSPACE/GRChombo/InstallNotes/MakeDefsLocalExamples/ubuntu-18.04.Make.defs.local $CHOMBO_HOME/mk/Make.defs.local
+        cp $GITHUB_WORKSPACE/GRChombo/InstallNotes/MakeDefsLocalExamples/ubuntu-gcc.Make.defs.local $CHOMBO_HOME/mk/Make.defs.local
         make -j 4 AMRTimeDependent AMRTools BaseTools BoxTools
       working-directory: ${{ env.CHOMBO_HOME }}
 

--- a/.github/workflows/build-BinaryBH-example.yml
+++ b/.github/workflows/build-BinaryBH-example.yml
@@ -1,6 +1,7 @@
 name: Build BinaryBH example with TwoPunctures
 
 on:
+  push: 
   schedule:
     # Run once per month
     - cron:  '0 0 1 * *'

--- a/Source/FuncAndJacobian.cpp
+++ b/Source/FuncAndJacobian.cpp
@@ -364,7 +364,7 @@ void TwoPunctures::F_of_v(int nvar, int n1, int n2, int n3, derivs v, double *F,
     {
         fclose(debugfile);
     }
-    free(sources);
+    delete[] sources;
     free_dvector(values, 0, nvar - 1);
     free_derivs(&U, nvar);
 }

--- a/Source/TP_Utilities.cpp
+++ b/Source/TP_Utilities.cpp
@@ -149,26 +149,28 @@ double ***d3tensor(long nrl, long nrh, long ncl, long nch, long ndl, long ndh)
 
 /*--------------------------------------------------------------------------*/
 void free_ivector(int *v, long nl, long nh)
-/* free an int vector allocated with ivector() */ { free(v + nl); }
+/* free an int vector allocated with ivector() */ { delete[](v + nl); }
 
 /*--------------------------------------------------------------------------*/
 void free_dvector(double *v, long nl, long nh)
-/* free an double vector allocated with dvector() */ { free(v + nl); }
+/* free an double vector allocated with dvector() */ { delete[](v + nl); }
 
 /*--------------------------------------------------------------------------*/
 void free_imatrix(int **m, long nrl, long nrh, long ncl, long nch)
 /* free an int matrix allocated by imatrix() */
 {
-    free(m[nrl] + ncl);
-    free(m + nrl);
+    for (int irow = nrl; irow <= nrh; ++irow)
+        delete[](m[irow] + ncl);
+    delete[](m + nrl);
 }
 
 /*--------------------------------------------------------------------------*/
 void free_dmatrix(double **m, long nrl, long nrh, long ncl, long nch)
 /* free a double matrix allocated by dmatrix() */
 {
-    free(m[nrl] + ncl);
-    free(m + nrl);
+    for (int irow = nrl; irow <= nrh; ++irow)
+        delete[](m[irow] + ncl);
+    delete[](m + nrl);
 }
 
 /*--------------------------------------------------------------------------*/
@@ -176,9 +178,15 @@ void free_d3tensor(double ***t, long nrl, long nrh, long ncl, long nch,
                    long ndl, long ndh)
 /* free a double d3tensor allocated by d3tensor() */
 {
-    free(t[nrl][ncl] + ndl);
-    free(t[nrl] + ncl);
-    free(t + nrl);
+    for (int irow = nrl; irow <= nrh; ++irow)
+    {
+        for (int icol = ncl; icol <= nch; ++icol)
+        {
+            delete[](t[irow][icol] + ndl);
+        }
+        delete[](t[irow] + ncl);
+    }
+    delete[](t + nrl);
 }
 
 /*--------------------------------------------------------------------------*/


### PR DESCRIPTION
Since this memory is allocated with the C++ `new []` operator, it should be deallocated with the corresponding `delete[]` operator. Valgrind picks this up as a "Mismatched free() / delete / delete []".

I've also updated the GitHub action to reflect changes in the GRChombo repo and set it to run on "push" (i.e. when new commits are pushed).